### PR TITLE
Correct RHBQ 3.2.10 version

### DIFF
--- a/openshift-ci/Dockerfile
+++ b/openshift-ci/Dockerfile
@@ -27,7 +27,7 @@ ENV PATH="${JAVA_HOME}/bin:$DIR/apache-maven-${MAVEN_VERSION}/bin:${PATH}"
 
 # these versions should be updated for every release
 ENV QUARKUS_BRANCH=3.2
-ENV QUARKUS_VERSION=3.2.10.Final-redhat-00003
+ENV QUARKUS_VERSION=3.2.10.Final-redhat-00002
 ENV QUARKUS_PLATFORM_GROUP_ID=com.redhat.quarkus.platform
 ENV QUARKUS_PLATFORM_ARTIFACT_ID=quarkus-bom
 


### PR DESCRIPTION
Here I set wrong RHB1 3.2.10 version https://github.com/quarkus-qe/quarkus-openshift-interop/pull/3

It should had been 3.2.10.Final-redhat-00002 https://maven.repository.redhat.com/ga/com/redhat/quarkus/platform/quarkus-bom/3.2.10.Final-redhat-00002/, however I set 3.2.10.Final-redhat-00003 as for https://mvnrepository.com/artifact/io.quarkus/quarkus-bom/3.2.10.Final-redhat-00003 (which has different group id `com.redhat` vs `io.quarkus`).

The difference is between platform and core

```
QUARKUS_PLATFORM_BOM_VERSION=3.2.10.Final-redhat-00002
QUARKUS_CORE_BOM_VERSION=3.2.10.Final-redhat-00003
```