### PR TITLE
Update to 3.8.5

### DIFF
--- a/openshift-ci/Dockerfile
+++ b/openshift-ci/Dockerfile
@@ -27,7 +27,7 @@ ENV PATH="${JAVA_HOME}/bin:$DIR/apache-maven-${MAVEN_VERSION}/bin:${PATH}"
 
 # these versions should be updated for every release
 ENV QUARKUS_BRANCH=3.8
-ENV QUARKUS_VERSION=3.8.4.redhat-00002
+ENV QUARKUS_VERSION=3.8.5.redhat-00003
 ENV QUARKUS_PLATFORM_GROUP_ID=com.redhat.quarkus.platform
 ENV QUARKUS_PLATFORM_ARTIFACT_ID=quarkus-bom
 

--- a/openshift-ci/Dockerfile
+++ b/openshift-ci/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR $DIR
 RUN dnf install -y git glibc-devel zlib-devel gcc freetype-devel libstdc++-static --setopt=install_weak_deps=False
 # ubi8 repos contain maven 3.5 and jdk 1.8; we need something newer
 # Install mandrel: https://github.com/graalvm/mandrel/releases
-ARG MANDREL_VERSION='22.3.5.0'
+ARG MANDREL_VERSION='23.0.4.1'
 ADD https://github.com/graalvm/mandrel/releases/download/mandrel-${MANDREL_VERSION}-Final/mandrel-java17-linux-amd64-${MANDREL_VERSION}-Final.tar.gz mandrel-java17-linux-amd64-${MANDREL_VERSION}-Final.tar.gz
 ADD https://github.com/graalvm/mandrel/releases/download/mandrel-${MANDREL_VERSION}-Final/mandrel-java17-linux-amd64-${MANDREL_VERSION}-Final.tar.gz.sha256 mandrel.sha256
 RUN sha256sum -c mandrel.sha256 && tar -xaf mandrel-java17-linux-amd64-${MANDREL_VERSION}-Final.tar.gz
@@ -18,7 +18,7 @@ RUN curl https://downloads.apache.org/maven/maven-3/3.9.6/binaries/apache-maven-
 RUN tar -xaf maven.tar.gz
 
 # install oc client
-ADD https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.14.5/openshift-client-linux-4.14.5.tar.gz oc.tar.gz
+ADD https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.15.21/openshift-client-linux-4.15.21.tar.gz oc.tar.gz
 RUN tar -xaf oc.tar.gz oc && mv oc /usr/local/bin/
 
 ENV JAVA_HOME="${DIR}/mandrel-java17-${MANDREL_VERSION}-Final"


### PR DESCRIPTION
Task: [QUARKUS-4363](https://issues.redhat.com/browse/QUARKUS-4363)

Also updating the version of ocp client to the one which was used for testing (4.15). If you want 4.16 is also available, don't know the details of this testing.

Updated mandrel version to the latest version which use JDK 17 as I was saw that this tests run native. 

Tested it on our ocp 4.16 cluster, see project `interop-jjedlick`. It seems working.