### PR TITLE
Add a comment that the script file is not used for testing

### DIFF
--- a/openshift-ci/run.sh
+++ b/openshift-ci/run.sh
@@ -3,6 +3,8 @@ set -eux
 
 export _JAVA_OPTIONS=-Duser.home=$HOME
 
+# The CI testing not using this file, to modify the mvn command
+# change this file https://github.com/openshift/release/blob/master/ci-operator/step-registry/quarkus/execute-tests/quarkus-execute-tests-commands.sh
 mvn -B -V clean verify -fae \
     -Dmaven.repo.local=$PWD/local-repo \
     -Dquarkus.platform.group-id=$QUARKUS_PLATFORM_GROUP_ID \


### PR DESCRIPTION
As per your suggestion in QQE-908 I adding the property to disable re-runs to have more cleaner and readable logs.