### PR TITLE
Upgrade maven version to 3.9.9 on Dockerfile

### DIFF
--- a/openshift-ci/Dockerfile
+++ b/openshift-ci/Dockerfile
@@ -12,9 +12,9 @@ ADD https://github.com/graalvm/mandrel/releases/download/mandrel-${MANDREL_VERSI
 ADD https://github.com/graalvm/mandrel/releases/download/mandrel-${MANDREL_VERSION}-Final/mandrel-java17-linux-amd64-${MANDREL_VERSION}-Final.tar.gz.sha256 mandrel.sha256
 RUN sha256sum -c mandrel.sha256 && tar -xaf mandrel-java17-linux-amd64-${MANDREL_VERSION}-Final.tar.gz
 # Install maven: https://maven.apache.org/install.html + https://maven.apache.org/download.cgi
-ARG MAVEN_VERSION='3.9.6'
+ARG MAVEN_VERSION='3.9.9'
 ADD https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz maven.tar.gz
-RUN curl https://downloads.apache.org/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz.sha512 > maven.sha512 && printf "\tmaven.tar.gz" >> maven.sha512 && sha512sum -c maven.sha512
+RUN curl https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz.sha512 > maven.sha512 && printf "\tmaven.tar.gz" >> maven.sha512 && sha512sum -c maven.sha512
 RUN tar -xaf maven.tar.gz
 
 # install oc client


### PR DESCRIPTION
As part of the task to upgrade maven to 3.9.9, most of our repositories where Maven have been already updated to 3.9.9.
Here has been modified the `MAVEN_VERSION` to 3.9.9 and the links related to the Dockerfile.