### PR TITLE
Use permanent link for maven downloads

### DIFF
--- a/openshift-ci/Dockerfile
+++ b/openshift-ci/Dockerfile
@@ -12,9 +12,9 @@ ADD https://github.com/graalvm/mandrel/releases/download/mandrel-${MANDREL_VERSI
 ADD https://github.com/graalvm/mandrel/releases/download/mandrel-${MANDREL_VERSION}-Final/mandrel-java21-linux-amd64-${MANDREL_VERSION}-Final.tar.gz.sha256 mandrel.sha256
 RUN sha256sum -c mandrel.sha256 && tar -xaf mandrel-java21-linux-amd64-${MANDREL_VERSION}-Final.tar.gz
 # Install maven: https://maven.apache.org/install.html + https://maven.apache.org/download.cgi
-ARG MAVEN_VERSION='3.9.9'
-ADD https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz maven.tar.gz
-RUN curl https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz.sha512 > maven.sha512 && printf "\tmaven.tar.gz" >> maven.sha512 && sha512sum -c maven.sha512
+ARG MAVEN_VERSION='3.9.10'
+ADD https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz maven.tar.gz
+RUN curl https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz.sha512 > maven.sha512 && printf "\tmaven.tar.gz" >> maven.sha512 && sha512sum -c maven.sha512
 RUN tar -xaf maven.tar.gz
 
 # install oc client


### PR DESCRIPTION
Apache removes previous maven verion from "downloads" as soon as the new one is released. We need to use "archives" link to keep access to them. Also, update to the latest maven release.